### PR TITLE
Make use of Embeds in all bot responses

### DIFF
--- a/ToxicBot/commands/admin.py
+++ b/ToxicBot/commands/admin.py
@@ -102,7 +102,9 @@ class ToxicBotAdminCommands(commands.Cog):
             count = int(arg)  # Value to set the count config to
         except Exception:
             # If numerical value is not passed
-            await ctx.send(embed=embedded.error(REQUIRE_NUMERICAL_VALUE.format(entity="Toxic Count Threshold Per User")))
+            await ctx.send(embed=embedded.error(
+                REQUIRE_NUMERICAL_VALUE.format(entity="Toxic Count Threshold Per User")
+            ))
             return
         member = ctx.author
         server_config = ServerConfig()
@@ -120,7 +122,9 @@ class ToxicBotAdminCommands(commands.Cog):
             SERVER_ID = server_config.modifyServerConfig(SERVER_OWNER_ID, server_id=SERVER_ID, count=count)
         guild = self.bot.get_guild(int(SERVER_ID))
         guild_name = guild.name if guild is not None else ""
-        await ctx.send(embed=embedded.yes(SUCCESSFUL_UPDATE.format(entity="Toxic Count Threshold Per User", server=guild_name)))
+        await ctx.send(embed=embedded.yes(
+            SUCCESSFUL_UPDATE.format(entity="Toxic Count Threshold Per User", server=guild_name)
+        ))
 
     # Used to set the days_threshold value in the server config
     @commands.command()
@@ -134,7 +138,9 @@ class ToxicBotAdminCommands(commands.Cog):
         try:
             days = int(arg)
         except Exception:
-            await ctx.send(embed=embedded.error(REQUIRE_NUMERICAL_VALUE.format(entity="Days before resetting toxic count for an user")))
+            await ctx.send(embed=embedded.error(
+                REQUIRE_NUMERICAL_VALUE.format(entity="Days before resetting toxic count for an user")
+            ))
             return
         member = ctx.author
         server_config = ServerConfig()

--- a/ToxicBot/commands/admin.py
+++ b/ToxicBot/commands/admin.py
@@ -159,12 +159,12 @@ class ToxicBotAdminCommands(commands.Cog):
         guild = self.bot.get_guild(int(SERVER_ID))
         guild_name = guild.name if guild is not None else ""
         # Send a success message to the user
-        await ctx.send(
+        await ctx.send(embed=embedded.success(
             SUCCESSFUL_UPDATE.format(
                 entity="Days before resetting toxic count for an user",
                 server=guild_name,
             )
-        )
+        ))
 
     # This command can be used to get the top n toxic comments for a particular server
     @commands.command()
@@ -172,7 +172,7 @@ class ToxicBotAdminCommands(commands.Cog):
     @commands.is_owner()
     async def toptoxic(self, ctx, arg=None):
         if arg is None:
-            await ctx.send(BAD_ARGUMENT)
+            await ctx.send(embed=embedded.error(BAD_ARGUMENT))
             return
         top = None
         try:

--- a/ToxicBot/commands/admin.py
+++ b/ToxicBot/commands/admin.py
@@ -1,6 +1,7 @@
 from discord.ext import commands
 import discord
 import asyncio
+from helper import embed as embedded
 from constants.messages import (
     SUCCESSFUL_UPDATE,
     REQUIRE_NUMERICAL_VALUE,
@@ -42,7 +43,7 @@ class ToxicBotAdminCommands(commands.Cog):
             if guild is not None:
                 guild_name = guild.name  # Get the guild name from server id
                 servers.append(guild_name)
-        await ctx.send(ADMIN_REQUEST_SERVER_ID)
+        await ctx.send(embed=embedded.info(ADMIN_REQUEST_SERVER_ID))
         embed = self.generate_embed("Servers", servers)
         await ctx.send(embed=embed)  # Send a multi-choice option to the user to select a specific server
         message = None
@@ -50,17 +51,17 @@ class ToxicBotAdminCommands(commands.Cog):
             # Wait for 5 seconds for response
             message = await self.bot.wait_for("message", timeout=5.0, check=check)
         except asyncio.TimeoutError:
-            await ctx.send(REQUEST_TIMEOUT)  # Send a timeout message
+            await ctx.send(embed=embedded.error(REQUEST_TIMEOUT))  # Send a timeout message
             return -1
         index = None
         try:
             index = int(message.content)  # Convert the string to number
         except Exception:
             # If non-numeric characters are passed
-            await ctx.send(REQUIRE_NUMERICAL_VALUE.format(entity="Server Number"))
+            await ctx.send(embed=embedded.error(REQUIRE_NUMERICAL_VALUE.format(entity="Server Number")))
             return -1
         if index > len(records):  # Check if index is out of bounds
-            await ctx.send(BAD_ARGUMENT)
+            await ctx.send(embed=embedded.error(BAD_ARGUMENT))
             return
         return index, records
 
@@ -84,7 +85,9 @@ class ToxicBotAdminCommands(commands.Cog):
         guild = self.bot.get_guild(int(SERVER_ID))
         guild_name = guild.name if guild is not None else ""
 
-        await ctx.send(ADMIN_CONFIG.format(guild=guild_name, count=record[1], time=record[2]))
+        await ctx.send(embed=embedded.yes(
+            ADMIN_CONFIG.format(guild=guild_name, count=record[1], time=record[2])
+        ))
 
     # Changes the toxic_count_config for that server
     @commands.command()
@@ -92,14 +95,14 @@ class ToxicBotAdminCommands(commands.Cog):
     @commands.is_owner()
     async def setcount(self, ctx, arg=None):
         if arg is None:
-            await ctx.send(BAD_ARGUMENT)
+            await ctx.send(embed=embedded.error(BAD_ARGUMENT))
             return
         count = None
         try:
             count = int(arg)  # Value to set the count config to
         except Exception:
             # If numerical value is not passed
-            await ctx.send(REQUIRE_NUMERICAL_VALUE.format(entity="Toxic Count Threshold Per User"))
+            await ctx.send(embed=embedded.error(REQUIRE_NUMERICAL_VALUE.format(entity="Toxic Count Threshold Per User")))
             return
         member = ctx.author
         server_config = ServerConfig()
@@ -117,7 +120,7 @@ class ToxicBotAdminCommands(commands.Cog):
             SERVER_ID = server_config.modifyServerConfig(SERVER_OWNER_ID, server_id=SERVER_ID, count=count)
         guild = self.bot.get_guild(int(SERVER_ID))
         guild_name = guild.name if guild is not None else ""
-        await ctx.send(SUCCESSFUL_UPDATE.format(entity="Toxic Count Threshold Per User", server=guild_name))
+        await ctx.send(embed=embedded.yes(SUCCESSFUL_UPDATE.format(entity="Toxic Count Threshold Per User", server=guild_name)))
 
     # Used to set the days_threshold value in the server config
     @commands.command()
@@ -125,13 +128,13 @@ class ToxicBotAdminCommands(commands.Cog):
     @commands.is_owner()
     async def setdays(self, ctx, arg=None):
         if arg is None:
-            await ctx.send(BAD_ARGUMENT)
+            await ctx.send(embed=embedded.error(BAD_ARGUMENT))
             return
         days = None
         try:
             days = int(arg)
         except Exception:
-            await ctx.send(REQUIRE_NUMERICAL_VALUE.format(entity="Days before resetting toxic count for an user"))
+            await ctx.send(embed=embedded.error(REQUIRE_NUMERICAL_VALUE.format(entity="Days before resetting toxic count for an user")))
             return
         member = ctx.author
         server_config = ServerConfig()
@@ -169,7 +172,9 @@ class ToxicBotAdminCommands(commands.Cog):
         try:
             top = int(arg)
         except Exception:
-            await ctx.send(REQUIRE_NUMERICAL_VALUE.format(entity="Number of entries required"))
+            await ctx.send(embed=embedded.error(
+                REQUIRE_NUMERICAL_VALUE.format(entity="Number of entries required")
+            ))
             return
         member = ctx.author
         server_config = ServerConfig()

--- a/ToxicBot/commands/admin.py
+++ b/ToxicBot/commands/admin.py
@@ -85,7 +85,7 @@ class ToxicBotAdminCommands(commands.Cog):
         guild = self.bot.get_guild(int(SERVER_ID))
         guild_name = guild.name if guild is not None else ""
 
-        await ctx.send(embed=embedded.yes(
+        await ctx.send(embed=embedded.success(
             ADMIN_CONFIG.format(guild=guild_name, count=record[1], time=record[2])
         ))
 
@@ -122,7 +122,7 @@ class ToxicBotAdminCommands(commands.Cog):
             SERVER_ID = server_config.modifyServerConfig(SERVER_OWNER_ID, server_id=SERVER_ID, count=count)
         guild = self.bot.get_guild(int(SERVER_ID))
         guild_name = guild.name if guild is not None else ""
-        await ctx.send(embed=embedded.yes(
+        await ctx.send(embed=embedded.success(
             SUCCESSFUL_UPDATE.format(entity="Toxic Count Threshold Per User", server=guild_name)
         ))
 

--- a/ToxicBot/commands/commands.py
+++ b/ToxicBot/commands/commands.py
@@ -36,11 +36,11 @@ class ToxicBotGeneralCommands(commands.Cog):
         try:
             server_config.getConfigFromUser(str(member.id))
         except commands.NotOwner:  # User does not own a server
-            await ctx.send(embed=embedded.info(HELP_MESSAGE.format(username=member.name)))
+            await ctx.send(embed=embedded.help(HELP_MESSAGE.format(username=member.name)))
             return
         except AttributeError:
             pass
-        await ctx.send(embed=embedded.info(ADMIN_HELP_MESSAGE.format(username=member.name)))
+        await ctx.send(embed=embedded.help(ADMIN_HELP_MESSAGE.format(username=member.name)))
 
     # Command to report any issues
     @commands.command()

--- a/ToxicBot/commands/commands.py
+++ b/ToxicBot/commands/commands.py
@@ -1,6 +1,7 @@
 from discord.ext import commands
 import discord
 
+from helper import embed as embedded
 from constants.messages import (
     ADMIN_HELP_MESSAGE,
     INFO_MESSAGE,
@@ -18,7 +19,7 @@ class ToxicBotGeneralCommands(commands.Cog):
     @commands.dm_only()
     async def info(self, ctx):
         member = ctx.author
-        await ctx.send(INFO_MESSAGE.format(username=member.name))
+        await ctx.send(embed=embedded.info(INFO_MESSAGE.format(username=member.name)))
 
     """
     There are two types of Help commands, one for server admins and one for
@@ -35,11 +36,11 @@ class ToxicBotGeneralCommands(commands.Cog):
         try:
             server_config.getConfigFromUser(str(member.id))
         except commands.NotOwner:  # User does not own a server
-            await ctx.send(HELP_MESSAGE.format(username=member.name))
+            await ctx.send(embed=embedded.info(HELP_MESSAGE.format(username=member.name)))
             return
         except AttributeError:
             pass
-        await ctx.send(ADMIN_HELP_MESSAGE.format(username=member.name))
+        await ctx.send(embed=embedded.info(ADMIN_HELP_MESSAGE.format(username=member.name)))
 
     # Command to report any issues
     @commands.command()

--- a/ToxicBot/commands/error.py
+++ b/ToxicBot/commands/error.py
@@ -1,7 +1,9 @@
 from discord import errors
 from discord.ext import commands
 from constants.messages import ONLY_PRIVATE_DMS, NOT_BOT_OWNER
+from helper import embed as embedded
 import logging
+
 
 logger = logging.getLogger("")
 
@@ -13,10 +15,10 @@ class ToxicBotError(commands.Cog):
     @commands.Cog.listener()
     async def on_command_error(self, ctx, error):
         if isinstance(error, commands.PrivateMessageOnly):  # If a private command is sent to a public channel
-            await ctx.channel.send(ONLY_PRIVATE_DMS.format(user=ctx.author.mention))
+            await ctx.channel.send(embed=embedded.error(ONLY_PRIVATE_DMS.format(user=ctx.author.mention)))
             return
         elif isinstance(error, commands.NotOwner):  # If user issues commands that can only be issued by the admin
-            await ctx.channel.send(NOT_BOT_OWNER.format(user=ctx.author.mention))
+            await ctx.channel.send(embed=embedded.error(NOT_BOT_OWNER.format(user=ctx.author.mention)))
             return
         elif isinstance(error, errors.Forbidden):
             logger.error(str(error))

--- a/ToxicBot/commands/listener.py
+++ b/ToxicBot/commands/listener.py
@@ -41,10 +41,10 @@ class ToxicBotListener(commands.Cog):
             # Send a message to the general channel
             general = find(lambda x: x.name == "general", guild.text_channels)
             if general and general.permissions_for(guild.me).send_messages:
-                await general.send(ADMIN_MESSAGE_AFTER_BOT_JOIN)
+                await general.send(embed=embedded.info(ADMIN_MESSAGE_AFTER_BOT_JOIN))
         else:
             await owner.create_dm()
-            await owner.dm_channel.send(ADMIN_MESSAGE_AFTER_BOT_JOIN)
+            await owner.dm_channel.send(embed=embedded.info(ADMIN_MESSAGE_AFTER_BOT_JOIN))
 
     # When a message is sent in the guild
     @commands.Cog.listener()
@@ -61,10 +61,10 @@ class ToxicBotListener(commands.Cog):
         if toxicity == 0:
             return
         await message.delete()  # Delete the message
-        await message.channel.send(REMOVAL_MESSAGE.format(username=message.author.mention))
+        await message.channel.send(embed=embedded.info(REMOVAL_MESSAGE.format(username=message.author.mention)))
         await message.author.create_dm()
         # Warn the author
-        await message.author.dm_channel.send(PERSONAL_MESSAGE_AFTER_REMOVAL)
+        await message.author.dm_channel.send(embed=embedded.info(PERSONAL_MESSAGE_AFTER_REMOVAL))
 
         USER_ID = str(message.author.id)
         SERVER_ID = str(message.guild.id)

--- a/ToxicBot/commands/listener.py
+++ b/ToxicBot/commands/listener.py
@@ -9,6 +9,7 @@ from constants.messages import (
     PERSONAL_MESSAGE_AFTER_REMOVAL,
     ADMIN_MESSAGE_AFTER_BOT_JOIN,
 )
+from helper import embed as embedded
 from classifier.classifier import predict_toxicity
 from database.toxic_count import ToxicCount
 from database.server_config import ServerConfig

--- a/ToxicBot/helper/embed.py
+++ b/ToxicBot/helper/embed.py
@@ -14,3 +14,4 @@ def as_embed(text: str, **kw) -> Embed:
 error   = partial(as_embed, color=0xff0000)
 warning = partial(as_embed, color=0xffff00)
 info    = partial(as_embed, color=0x0000ff)
+yes     = partial(as_embed, color=0x00ff00)

--- a/ToxicBot/helper/embed.py
+++ b/ToxicBot/helper/embed.py
@@ -1,8 +1,16 @@
+from functools import partial
 from discord import Embed
 
 
-def as_embed(text: str) -> Embed:
+def as_embed(text: str, **kw) -> Embed:
     return Embed(
-        title='ToxixBot says',
-        description=text
+        type='rich',
+        title='ToxicBot says',
+        description=text,
+        **kw
     )
+
+
+error   = partial(as_embed, color=0xff0000)
+warning = partial(as_embed, color=0xffff00)
+info    = partial(as_embed, color=0x0000ff)

--- a/ToxicBot/helper/embed.py
+++ b/ToxicBot/helper/embed.py
@@ -27,4 +27,4 @@ def as_embed(
 error = partial(as_embed, color=0xff0000, title='Oops!')
 warning = partial(as_embed, color=0xffff00, title='Beware ...')
 info = partial(as_embed, color=0x0000ff, title='Just so you know')
-yes = partial(as_embed, color=0x00ff00, title='You did it!')
+success = partial(as_embed, color=0x00ff00, title='You did it!')

--- a/ToxicBot/helper/embed.py
+++ b/ToxicBot/helper/embed.py
@@ -39,6 +39,7 @@ def as_embed(
     return em
 
 
-error = partial(as_embed, color=0xff041b, title='Oops!', footer='Error')
-info = partial(as_embed, color=0xb900ff, title='Just so you know', footer='Info')
-success = partial(as_embed, color=0x6fc12e, title='You did it!', footer='Success')
+error = partial(as_embed, color=0xff041b, title='Error')
+info = partial(as_embed, color=0xCA45FF)
+help = partial(as_embed, color=0xCA45FF, title='Help')
+success = partial(as_embed, color=0x6fc12e, title='Success')

--- a/ToxicBot/helper/embed.py
+++ b/ToxicBot/helper/embed.py
@@ -3,6 +3,21 @@ from typing import Optional
 from discord import Embed
 
 
+"""
+Utils to produce Discord Embed constructs.
+
+You can use the partials `error`, `success` and `info` to apply a style more relevant
+to the nature of the message you want to embed, e.g.
+
+error => red border
+success => green border
+info => blue/your default custom color
+
+Feel free to create others depending on your needs.
+
+"""
+
+
 def as_embed(
     text: str,
     *,
@@ -10,6 +25,7 @@ def as_embed(
     title: Optional[str] = None,
     **kw
 ) -> Embed:
+    """Wrap a string around a stylized discord Embed object."""
     if title is None:
         title = 'Toxic Bot Message'
     em = Embed(

--- a/ToxicBot/helper/embed.py
+++ b/ToxicBot/helper/embed.py
@@ -1,17 +1,30 @@
 from functools import partial
+from typing import Optional
 from discord import Embed
 
 
-def as_embed(text: str, **kw) -> Embed:
-    return Embed(
+def as_embed(
+    text: str,
+    *,
+    footer: Optional[str] = None,
+    title: Optional[str] = None,
+    **kw
+) -> Embed:
+    if title is None:
+        title = 'Toxic Bot Message'
+    em = Embed(
         type='rich',
-        title='ToxicBot says',
+        title=title,
         description=text,
         **kw
     )
+    em.set_author(name='Toxic Bot')
+    if footer is not None:
+        em.set_footer(text=footer)
+    return em
 
 
-error   = partial(as_embed, color=0xff0000)
-warning = partial(as_embed, color=0xffff00)
-info    = partial(as_embed, color=0x0000ff)
-yes     = partial(as_embed, color=0x00ff00)
+error = partial(as_embed, color=0xff0000, title='Oops!')
+warning = partial(as_embed, color=0xffff00, title='Beware ...')
+info = partial(as_embed, color=0x0000ff, title='Just so you know')
+yes = partial(as_embed, color=0x00ff00, title='You did it!')

--- a/ToxicBot/helper/embed.py
+++ b/ToxicBot/helper/embed.py
@@ -39,6 +39,6 @@ def as_embed(
     return em
 
 
-error = partial(as_embed, color=0xff041b, title='Oops!')
-info = partial(as_embed, color=0xb900ff, title='Just so you know')
-success = partial(as_embed, color=0x6fc12e, title='You did it!')
+error = partial(as_embed, color=0xff041b, title='Oops!', footer='Error')
+info = partial(as_embed, color=0xb900ff, title='Just so you know', footer='Info')
+success = partial(as_embed, color=0x6fc12e, title='You did it!', footer='Success')

--- a/ToxicBot/helper/embed.py
+++ b/ToxicBot/helper/embed.py
@@ -39,6 +39,6 @@ def as_embed(
     return em
 
 
-error = partial(as_embed, color=0xff0000, title='Oops!')
-info = partial(as_embed, color=0x0000ff, title='Just so you know')
-success = partial(as_embed, color=0x00ff00, title='You did it!')
+error = partial(as_embed, color=0xff041b, title='Oops!')
+info = partial(as_embed, color=0xb900ff, title='Just so you know')
+success = partial(as_embed, color=0x6fc12e, title='You did it!')

--- a/ToxicBot/helper/embed.py
+++ b/ToxicBot/helper/embed.py
@@ -27,7 +27,7 @@ def as_embed(
     title: Optional[str] = None,
     **kw
 ) -> Embed:
-    """Wrap a string around a stylized discord Embed object."""
+    """Wrap a string in a stylized discord Embed object."""
     em = Embed(
         type='rich',
         title=title or 'Toxic Bot',

--- a/ToxicBot/helper/embed.py
+++ b/ToxicBot/helper/embed.py
@@ -15,6 +15,8 @@ info => blue/your default custom color
 
 Feel free to create others depending on your needs.
 
+You can try them out here:
+# https://leovoel.github.io/embed-visualizer/
 """
 
 
@@ -26,15 +28,12 @@ def as_embed(
     **kw
 ) -> Embed:
     """Wrap a string around a stylized discord Embed object."""
-    if title is None:
-        title = 'Toxic Bot Message'
     em = Embed(
         type='rich',
-        title=title,
+        title=title or 'Toxic Bot',
         description=text,
         **kw
     )
-    em.set_author(name='Toxic Bot')
     if footer is not None:
         em.set_footer(text=footer)
     return em

--- a/ToxicBot/helper/embed.py
+++ b/ToxicBot/helper/embed.py
@@ -1,0 +1,8 @@
+from discord import Embed
+
+
+def as_embed(text: str) -> Embed:
+    return Embed(
+        title='ToxixBot says',
+        description=text
+    )

--- a/ToxicBot/helper/embed.py
+++ b/ToxicBot/helper/embed.py
@@ -40,6 +40,6 @@ def as_embed(
 
 
 error = partial(as_embed, color=0xff041b, title='Error')
-info = partial(as_embed, color=0xCA45FF)
+info = partial(as_embed, color=0xCA45FF, title='Info')
 help = partial(as_embed, color=0xCA45FF, title='Help')
 success = partial(as_embed, color=0x6fc12e, title='Success')

--- a/ToxicBot/helper/embed.py
+++ b/ToxicBot/helper/embed.py
@@ -25,6 +25,5 @@ def as_embed(
 
 
 error = partial(as_embed, color=0xff0000, title='Oops!')
-warning = partial(as_embed, color=0xffff00, title='Beware ...')
 info = partial(as_embed, color=0x0000ff, title='Just so you know')
 success = partial(as_embed, color=0x00ff00, title='You did it!')


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change.
Happy Contributing!
-->

# Description

#19 
The module `helper/embed.py` provides helper functions to convert string messages into Embeds. In addition to the base case `as_embed(text: str)  -> Embed`, this PR provides a few options to make messages more meaningful by styling the output Embed, not unlike log levels:
* `embed.info` for a message with no particular severity (help, initialization details);
* `embed.error` for error messages (e.g. missing command parameters);
* `embed.success` for messages expressing success in performing a command.

I used these to convert all `(channel|ctx).send` calls so that they send an Embed element to Discord instead of a raw string, as #19 was suggesting.

I used the helpful https://leovoel.github.io/embed-visualizer/ to make sure the Embeds looked right & test the functions in `helper/embed.py`.

<!--
Replace `issue_no` with the issue number which is fixed in this PR
-->

## Have you read the [Contributing Guidelines on Pull Requests](https://github.com/Sid200026/ToxicBot/blob/master/CONTRIBUTING.md)?

- [x] Yes
- [ ] No

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation Update
